### PR TITLE
fix(cert): E-mail message format

### DIFF
--- a/cert/backend/src/utils/template_content.py
+++ b/cert/backend/src/utils/template_content.py
@@ -23,7 +23,7 @@ class TemplateContent:
         body = f"""
 안녕하세요, {recipient_name}님!
 
-PseudoLab {course_name} {season} 수료를 축하드립니다! 🎉
+PseudoLab {course_name} {season}기 수료를 축하드립니다! 🎉
 
 📋 활동 정보:
 • 스터디명: {course_name}
@@ -34,6 +34,6 @@ PseudoLab {course_name} {season} 수료를 축하드립니다! 🎉
 앞으로도 많은 관심과 참여 부탁드립니다! 🚀
 
 감사합니다.
-PseudoLab 팀
+PseudoLab 드림
         """
         return body


### PR DESCRIPTION
<img width="380" height="352" alt="image" src="https://github.com/user-attachments/assets/22027c1f-0f83-4e3b-b092-360079ae0612" />


- `{season}`은 기수를 나타내는 숫자기 때문에, `{season}기`로 표기 변경
- 가짜연구소 단체를 나타내기 위해 `PseudoLab 팀`에서 `PseudoLab 드림`으로 문구 변경