### PR TITLE
fix(getcloser): HTTPS to HTTP redirect issue

### DIFF
--- a/getcloser/.env.example
+++ b/getcloser/.env.example
@@ -9,3 +9,10 @@ DB_DATABASE=app_db
 
 # === App Host ===
 APP_HOST=localhost
+
+# === Trusted Hosts Config ===
+# Comma-separated list of trusted hostnames for the application.
+# This protects against HTTP Host header attacks.
+# In production, replace "*" with your actual domain names (e.g., "yourdomain.com,www.yourdomain.com").
+# For development, "localhost" is usually sufficient.
+TRUSTED_HOSTS=localhost

--- a/getcloser/backend/app/main.py
+++ b/getcloser/backend/app/main.py
@@ -1,5 +1,6 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from starlette.middleware.trustedhost import TrustedHostMiddleware
 from fastapi.openapi.utils import get_openapi
 from dotenv import load_dotenv
 import os
@@ -25,6 +26,7 @@ app = FastAPI(
     version="1.0.0",
     docs_url="/docs",
     redoc_url="/redoc",
+    root_path="/api",
 )
 
 # Swagger 기본 경로를 /api 로 지정
@@ -52,6 +54,15 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+# Add TrustedHostMiddleware to handle X-Forwarded-Proto headers
+
+# Add TrustedHostMiddleware to handle X-Forwarded-Proto headers
+trusted_hosts = os.getenv("TRUSTED_HOSTS", "*").split(",")
+if "*" not in trusted_hosts: # If "*" is present, it means all hosts are allowed, so no need to add "localhost"
+    trusted_hosts.append("localhost") # Always allow localhost for development
+app.add_middleware(TrustedHostMiddleware, allowed_hosts=trusted_hosts)
+
 
 app.include_router(api_router, prefix="/v1")
 app.include_router(test_db.test_router)


### PR DESCRIPTION
### 📝 PR 타입
<!-- 해당하는 타입에 대괄호 안에 x를 입력해주세요. -->
- [x] 버그 수정 (fix)
- [ ] 신규 기능 (feat)
- [ ] 문서 업데이트 (docs)
- [ ] 코드 스타일 / 포맷팅 (style)
- [ ] 리팩토링 (refactor)
- [ ] 테스트 (test)
- [ ] 기타 (chore, ci 등)

---
### 📜 설명
<!-- 무엇에 대한 PR인지 간결하게 설명해주세요. -->
FastAPI isn't configured for SSL termination behind a reverse proxy. The application likely generates HTTP URLs or redirects because it perceives HTTP requests from Traefik.

### 엮인 이슈
<!-- 이 PR이 닫을 이슈가 있다면, `Closes #이슈번호`를 사용해주세요. -->
- Closes #


---

### 🔨 작업 내용
<!-- 변경된 내용을 간략하게 요약하여 작성합니다. -->
- Add TrustedHostMiddleware to inform FastAPI to trust proxy headers like X-Forwarded-Proto, and set root_path="/api" in the FastAPI constructor to ensure correct URL generation when behind Traefik's /api prefix.

### 📸 스크린샷
<!-- UI 변경이 포함된 경우, 스크린샷을 첨부를 권장합니다. -->


---

### 🧑‍💻 테스트 결과
<!-- 이 변경 사항을 어떻게 테스트했는지 설명합니다. -->


---

### 📅 체크리스트
- [ ] 이해하기 어려운 부분에 주석을 추가했습니다.
- [ ] 관련된 문서를 업데이트했습니다.
